### PR TITLE
Reposition Medical History on GUI

### DIFF
--- a/src/main/java/seedu/address/model/person/MedicalHistory.java
+++ b/src/main/java/seedu/address/model/person/MedicalHistory.java
@@ -110,6 +110,30 @@ public class MedicalHistory {
         return this.entryList.size();
     }
 
+    /**
+     * Returns the string representation of Medical History as displayed on the app.
+     * @return string representation for GUI.
+     */
+    public String display(String emoji) {
+        if (this.isEmpty()) {
+            return "No medical history recorded.";
+        }
+        int size = entryList.size();
+        StringBuilder s = new StringBuilder();
+        StringBuilder icon = new StringBuilder(emoji + "\t");
+
+        for (int i = 0; i < size; i++) {
+            if (i == size - 1) {
+                s = s.append(icon).append(entryList.get(i));
+            } else {
+                s = s.append(icon).append(entryList.get(i)).append("\n");
+            }
+        }
+
+        return s.toString();
+
+    }
+
     @Override
     public String toString() { // to store the list into a CSV format
         int size = this.entryList.size();

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -62,11 +62,7 @@ public class PersonCard extends UiPart<Region> {
         patient.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        if (!patient.getMedicalHistory().isEmpty()) {
-            medicalHistory.setText(MEDICAL_HISTORY_ICON + "\t" + patient.getMedicalHistory());
-        } else {
-            medicalHistory.setVisible(false);
-        }
+        medicalHistory.setText(patient.getMedicalHistory().display(MEDICAL_HISTORY_ICON));
 
     }
 

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -193,6 +193,13 @@
     -fx-text-fill: #010504;
 }
 
+.cell_small_label_bold {
+    -fx-font-family: "Segoe UI";
+    -fx-font-size: 13px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #010504;
+}
+
 .stack-pane {
      -fx-background-color: derive(#ffffff, 20%);
 }
@@ -202,13 +209,14 @@
      -fx-background-radius: 10px;
      -fx-border-color: derive(#eeeeee, 50%);
      -fx-border-width: 0px;
-     -fx-border-radius: 10px;
+     -fx-border-radius: 10;
 }
 
 .pane-with-border {
      -fx-background-color: derive(ffffff, 50%);
      -fx-border-color: derive(#cccccc, 50%);
      -fx-border-width: 1px;
+     -fx-border-radius: 10;
 }
 
 .pane-with-shadow {
@@ -222,6 +230,7 @@
 
 .pane-transparent {
     -fx-background-color: transparent;
+    -fx-border-radius: 10;
 }
 
 .status-bar {
@@ -233,10 +242,12 @@
     -fx-font-family: "Droid Sans Mono";
     -fx-font-size: 10pt;
     -fx-text-fill: #444444;
+    -fx-border-radius: 10;
 }
 
 .result-display .label {
     -fx-text-fill: black !important;
+    -fx-border-radius: 10;
 }
 
 .status-bar .label {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -51,7 +51,7 @@
                   </ButtonBar>
                </children>
             </HBox>
-                <SplitPane dividerPositions="0.3166023166023166" prefHeight="724.0" prefWidth="1038.0" styleClass="pane-without-border" VBox.vgrow="ALWAYS">
+                <SplitPane dividerPositions="0.5" prefHeight="724.0" prefWidth="1038.0" styleClass="pane-without-border" VBox.vgrow="ALWAYS">
                     <items>
 
                         <VBox fx:id="patientList" minWidth="297.0" prefHeight="722.0" prefWidth="297.0" styleClass="pane-without-border">

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -10,40 +10,62 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.SplitPane?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
         </columnConstraints>
-        <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
-            <padding>
-                <Insets bottom="5" left="15" right="5" top="5" />
-            </padding>
-            <HBox alignment="CENTER_LEFT" spacing="5">
-                <Label fx:id="id" styleClass="cell_big_label">
-                    <minWidth>
-                        <!-- Ensures that the label text is never truncated -->
-                        <Region fx:constant="USE_PREF_SIZE" />
-                    </minWidth>
-                </Label>
-                <Label fx:id="name" styleClass="cell_big_label" text="\$first">
-                    <HBox.margin>
-                        <Insets />
-                    </HBox.margin></Label>
-                <opaqueInsets>
-                    <Insets />
-                </opaqueInsets>
-            </HBox>
-            <FlowPane fx:id="tags">
-                <padding>
-                    <Insets bottom="5.0" />
-                </padding></FlowPane>
-
-            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-            <Label fx:id="medicalHistory" styleClass="cell_small_label" text="\$medicalHistory" />
-        </VBox>
+        <SplitPane dividerPositions="0.6" stylesheets="@LightTheme.css">
+            <items>
+                <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0" prefWidth="250">
+                    <padding>
+                        <Insets bottom="5" left="15" right="5" top="5" />
+                    </padding>
+                    <HBox alignment="CENTER_LEFT" spacing="5">
+                        <Label fx:id="id" styleClass="cell_big_label">
+                            <minWidth>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minWidth>
+                        </Label>
+                        <Label fx:id="name" styleClass="cell_big_label" text="\$first">
+                            <HBox.margin>
+                                <Insets />
+                            </HBox.margin></Label>
+                        <opaqueInsets>
+                            <Insets />
+                        </opaqueInsets>
+                    </HBox>
+                    <FlowPane fx:id="tags">
+                        <padding>
+                            <Insets bottom="5.0" />
+                        </padding></FlowPane>
+                    <children>
+                        <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
+                        <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+                        <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
+                    </children>
+                </VBox>
+                <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="1" prefWidth="90">
+                    <padding>
+                        <Insets bottom="5" left="15" right="5" top="5" />
+                    </padding>
+                    <HBox alignment="TOP_CENTER" spacing="5">
+                        <Label text="Medical History" styleClass="cell_small_label_bold">
+                            <minWidth>
+                                <!-- Ensures that the label text is never truncated -->
+                                <Region fx:constant="USE_PREF_SIZE" />
+                            </minWidth>
+                        </Label>
+                    </HBox>
+                    <children>
+                        <Label fx:id="medicalHistory" styleClass="cell_small_label" text="\$medicalHistory"
+                               wrapText="true"/>
+                    </children>
+                </VBox>
+            </items>
+        </SplitPane>
         <rowConstraints>
             <RowConstraints />
         </rowConstraints>


### PR DESCRIPTION
This PR resolves #125.

It separates out the Medical History from a single field into a list field on the PersonCard. 

Other smaller changes include:
1. Re-proportioning the real estate allocated to PersonList and AppointmentList

![telegram-cloud-photo-size-5-6316439606173741524-y](https://user-images.githubusercontent.com/51285113/138594242-6fd5e4c3-89fa-4fd1-98e4-3017ad6e3405.jpg)
