### PR TITLE
Disable list prescription command

### DIFF
--- a/src/main/java/seedu/docit/logic/parser/AppointmentBookParser.java
+++ b/src/main/java/seedu/docit/logic/parser/AppointmentBookParser.java
@@ -11,11 +11,9 @@ import seedu.docit.logic.commands.ListAppointmentsCommand;
 import seedu.docit.logic.commands.SortAppointmentsCommand;
 import seedu.docit.logic.commands.prescription.AddPrescriptionCommand;
 import seedu.docit.logic.commands.prescription.DeletePrescriptionCommand;
-import seedu.docit.logic.commands.prescription.ListPrescriptionsCommand;
 import seedu.docit.logic.parser.exceptions.ParseException;
 import seedu.docit.logic.parser.prescription.AddPrescriptionCommandParser;
 import seedu.docit.logic.parser.prescription.DeletePrescriptionCommandParser;
-import seedu.docit.logic.parser.prescription.ListPrescriptionsCommandParser;
 
 /**
  * Parses user input.


### PR DESCRIPTION
This command is redundant for now.
The command is removed from AppointmentBookParser class.