### PR TITLE
Fix UG for prescriptions and add tab-swap functionality

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -306,7 +306,7 @@ Adds an appointment for the patient at the specified index in the Patients panel
 * `apmt add i/2 d/2022-12-31 0700` adds appointment on 31 Dec 2022 at 7am to patient at index 2.
 
 ### List all appointments: `apmt list`
-Shows a list of all appointments.
+Shows the list of all appointments.
 
 **Format:** `apmt list`
 
@@ -315,6 +315,23 @@ Shows a list of all appointments.
 
 **Expected Outcome:**
 ```
+[UI CARDS]
+1. Patient Name: Joshen Lim | Appointment Date: 2021-10-05
+2. Patient Name: Ian Yong | Appointment Date: 2021-10-06
+3. Patient Name: Didy Ne | Appointment Date: 2021-11-23
+```
+
+### List all archived appointments: `apmt alist`
+Shows the list of all archived appointments.
+
+**Format:** `apmt alist`
+
+**Examples:**
+* `apmt alist`  Lists all archived appointments.
+
+**Expected Outcome:**
+```
+[UI CARDS]
 1. Patient Name: Joshen Lim | Appointment Date: 2021-10-05
 2. Patient Name: Ian Yong | Appointment Date: 2021-10-06
 3. Patient Name: Didy Ne | Appointment Date: 2021-11-23
@@ -398,7 +415,7 @@ Adds a prescription to the designated appointment.
 
 **Expected Outcome:**
 ```
-New prescription added
+New prescription added:
 Medicine: Penicillin
 Volume: 400 ml
 Duration: 2 times a week
@@ -407,14 +424,17 @@ Duration: 2 times a week
 ## Delete prescription: `apmt pd`
 Deletes a prescription from the designated appointment.
 
-**Format:** `apmt pa i/APMT_INDEX n/MEDICINE_NAME`
+**Format:** `apmt pd i/APMT_INDEX n/MEDICINE_NAME`
 
 **Examples:**
-* `apmt pd i/1 n/Penicillin `
+* `apmt pd i/1 n/panadol`
 
 **Expected Outcome:**
 ```
-Deleted prescription
+Deleted prescription: 
+Medicine: panadol
+
+from John Doe's appointment.
 ```
 ---
 
@@ -446,14 +466,15 @@ Deleted prescription
 | List    | `pt list`                                                                                   | -                                                                                                  |
 
 ### Appointment-related Commands
-| Command | Format                                                | Example                         |
-|---------|-------------------------------------------------------|---------------------------------|
-| Add     | `apmt add INDEX d/DATETIME`                           | `apmt add 1 d/2021-10-05 1600`  |
-| Edit    | `apmt edit APMT_INDEX [i/PATIENT_INDEX] [d/DATETIME]` | `apmt edit 1 d/2021-10-05 1600` |
-| Delete  | `apmt delete INDEX`                                   | `apmt delete 1`                 |
-| Archive | `apmt archive INDEX`                                  | `apmt archive 1`                |
-| List    | `apmt list`                                           | -                               |
-| Sort    | `apmt sort`                                           | -                               |
+| Command       | Format                                                | Example                         |
+|---------------|-------------------------------------------------------|---------------------------------|
+| Add           | `apmt add INDEX d/DATETIME`                           | `apmt add 1 d/2021-10-05 1600`  |
+| Edit          | `apmt edit APMT_INDEX [i/PATIENT_INDEX] [d/DATETIME]` | `apmt edit 1 d/2021-10-05 1600` |
+| Delete        | `apmt delete INDEX`                                   | `apmt delete 1`                 |
+| Archive       | `apmt archive INDEX`                                  | `apmt archive 1`                |
+| List          | `apmt list`                                           | -                               |
+| List Archived | `apmt alist`                                          | -                               |
+| Sort          | `apmt sort`                                           | -                               |
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/docit/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/docit/logic/commands/CommandResult.java
@@ -17,13 +17,17 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** Tab is swapped to archive. */
+    private final boolean showArchived;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean showArchived) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.showArchived = showArchived;
     }
 
     /**
@@ -31,7 +35,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -45,6 +49,11 @@ public class CommandResult {
     public boolean isExit() {
         return exit;
     }
+
+    public boolean isShowArchived() {
+        return showArchived;
+    }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/docit/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/ExitCommand.java
@@ -15,7 +15,7 @@ public class ExitCommand extends BasicCommand {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/seedu/docit/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends BasicCommand {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/seedu/docit/logic/commands/ListArchivedAppointmentsCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/ListArchivedAppointmentsCommand.java
@@ -6,18 +6,18 @@ import static seedu.docit.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 import seedu.docit.model.Model;
 
 /**
- * Lists all appointments in the address book to the user.
+ * Lists all archived appointments in the address book to the user.
  */
-public class ListAppointmentsCommand extends AppointmentCommand {
+public class ListArchivedAppointmentsCommand extends AppointmentCommand {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "alist";
 
-    public static final String MESSAGE_SUCCESS = "Listed all appointments";
+    public static final String MESSAGE_SUCCESS = "Listed all archived appointments";
 
 
     @Override public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false, false);
+        return new CommandResult(MESSAGE_SUCCESS, false, false, true);
     }
 }

--- a/src/main/java/seedu/docit/logic/commands/prescription/AddPrescriptionCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/prescription/AddPrescriptionCommand.java
@@ -34,7 +34,8 @@ public class AddPrescriptionCommand extends AppointmentCommand {
                     + CliSyntax.PREFIX_VOLUME + "400 ml "
                     + CliSyntax.PREFIX_DURATION + "2 times a week ";
 
-    public static final String MESSAGE_SUCCESS = "New prescription added";
+    public static final String MESSAGE_SUCCESS = "New prescription added: \nMedicine: %1$s\n"
+            + "Volume: %2$s\nDuration: %3$s";
     public static final String MESSAGE_DUPLICATE_MEDICINE =
             "This medicine already exists in the prescription for this appointment";
 
@@ -77,6 +78,6 @@ public class AddPrescriptionCommand extends AppointmentCommand {
 
         model.addPrescription(appointmentToMakePrescription, prescriptionToAdd);
         model.updateFilteredAppointmentList(Model.PREDICATE_SHOW_ALL_APPOINTMENTS);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, prescriptionToAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, medicine, volume, duration));
     }
 }

--- a/src/main/java/seedu/docit/logic/commands/prescription/DeletePrescriptionCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/prescription/DeletePrescriptionCommand.java
@@ -29,7 +29,8 @@ public class DeletePrescriptionCommand extends AppointmentCommand {
             + CliSyntax.PREFIX_INDEX + "1 "
             + CliSyntax.PREFIX_NAME + "Penicillin ";
 
-    public static final String MESSAGE_DELETE_PRESCRIPTION_SUCCESS = "Deleted prescription";
+    public static final String MESSAGE_DELETE_PRESCRIPTION_SUCCESS = "Deleted prescription: \nMedicine: %1$s\n\n"
+            + "from %2$s's appointment.";
 
     private final Index targetAppointmentIndex;
     private final String targetMedicineName;
@@ -55,7 +56,8 @@ public class DeletePrescriptionCommand extends AppointmentCommand {
         Appointment appointmentToTarget = lastShownList.get(targetAppointmentIndex.getZeroBased());
         try {
             model.deletePrescription(appointmentToTarget, targetMedicineName);
-            return new CommandResult(MESSAGE_DELETE_PRESCRIPTION_SUCCESS);
+            return new CommandResult(String.format(MESSAGE_DELETE_PRESCRIPTION_SUCCESS,
+                    targetMedicineName, appointmentToTarget.getPatient().getName()));
         } catch (MedicineNotFoundException e) {
             throw new CommandException(e.getMessage());
         }

--- a/src/main/java/seedu/docit/logic/parser/AppointmentBookParser.java
+++ b/src/main/java/seedu/docit/logic/parser/AppointmentBookParser.java
@@ -8,6 +8,7 @@ import seedu.docit.logic.commands.ArchiveAppointmentCommand;
 import seedu.docit.logic.commands.DeleteAppointmentCommand;
 import seedu.docit.logic.commands.EditAppointmentCommand;
 import seedu.docit.logic.commands.ListAppointmentsCommand;
+import seedu.docit.logic.commands.ListArchivedAppointmentsCommand;
 import seedu.docit.logic.commands.SortAppointmentsCommand;
 import seedu.docit.logic.commands.prescription.AddPrescriptionCommand;
 import seedu.docit.logic.commands.prescription.DeletePrescriptionCommand;
@@ -38,6 +39,8 @@ public class AppointmentBookParser {
             return new ArchiveAppointmentCommandParser().parseAppointmentCommand(arguments);
         case ListAppointmentsCommand.COMMAND_WORD:
             return new ListAppointmentsCommand();
+        case ListArchivedAppointmentsCommand.COMMAND_WORD:
+            return new ListArchivedAppointmentsCommand();
         case SortAppointmentsCommand.COMMAND_WORD:
             return new SortAppointmentsCommand();
         case AddPrescriptionCommand.COMMAND_WORD:

--- a/src/main/java/seedu/docit/ui/MainWindow.java
+++ b/src/main/java/seedu/docit/ui/MainWindow.java
@@ -6,6 +6,7 @@ import java.util.logging.Logger;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.TabPane;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -63,6 +64,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane statusbarPlaceholder;
+
+    @FXML
+    private TabPane tabsPlaceholder;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -171,6 +175,20 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Selects the Upcoming tab.
+     */
+    private void handleShowUpcomingTab() {
+        tabsPlaceholder.getSelectionModel().select(0);
+    }
+
+    /**
+     * Selects the Archived tab.
+     */
+    private void handleShowArchivedTab() {
+        tabsPlaceholder.getSelectionModel().select(1);
+    }
+
+    /**
      * Opens the help window or focuses on it if it's already opened.
      */
     @FXML
@@ -215,6 +233,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isShowHelp()) {
                 handleHelp();
+            } else if (commandResult.isShowArchived()) {
+                handleShowArchivedTab();
+            } else {
+                handleShowUpcomingTab();
             }
 
             if (commandResult.isExit()) {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -17,7 +17,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="700" minWidth="1200" onCloseRequest="#handleExit" title="Doc'it" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="700" minWidth="1200" onCloseRequest="#handleExit" title="Doc'it" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/DocitIcon.png" />
     </icons>
@@ -75,7 +75,7 @@
                                         <Font name="Segoe UI" size="24.0" />
                                     </font>
                                 </Label>
-                        <TabPane prefHeight="200.0" prefWidth="427.0" stylesheets="@LightTheme.css" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS">
+                        <TabPane fx:id="tabsPlaceholder" prefHeight="200.0" prefWidth="427.0" stylesheets="@LightTheme.css" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS">
                           <tabs>
                             <Tab text="Upcoming">
                                  <content>

--- a/src/test/java/seedu/docit/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/docit/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
     }
 
     @Test
@@ -46,9 +46,9 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
     }
 }

--- a/src/test/java/seedu/docit/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/docit/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/docit/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/docit/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
## Bug fixes
- Fix User Guide example outputs for Add Prescription and Delete Prescription
  - Fixes #221 and fixes #214 
- Add `alist` command to list archived appointments. This closes #203 by allowing users to swap tabs with CLI (not a new feature)
  - Implementation details: new boolean attribute `showArchived` added to CommandResult constructor.