### PR TITLE
Fix multiple PED bugs, more restrictive parsers, UG expected outcomes for Appointments

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -26,9 +26,13 @@ reduce man-hours in managing paper files, translating this saved time into bette
     3. [Appointment-related Commands](#appointment-commands)
        - [Add an appointment](#add-an-appointment-apmt-add)
        - [List all appointments](#list-all-appointments-apmt-list)
+       - [List all archived appointments](#list-all-archived-appointments-apmt-alist)
        - [Edit an appointment](#edit-an-appointment-apmt-edit)
        - [Delete an appointment](#delete-an-appointment-apmt-delete)
        - [Archive an appointment](#archive-an-appointment-apmt-archive)
+       - [Sort all appointments](#sort-all-appointments-apmt-sort)
+       - [Add prescription](#add-prescription-apmt-pa)
+       - [Delete prescription](#delete-prescription-apmt-pd)
 4. [FAQ](#faq)
 5. [Command Summary](#command-summary)
 6. [Glossary](#glossary)
@@ -305,6 +309,15 @@ Adds an appointment for the patient at the specified index in the Patients panel
 * `apmt add i/1 d/2021-10-05 1500` adds appointment on 5 Oct 2021 at 3pm to patient at index 1.
 * `apmt add i/2 d/2022-12-31 0700` adds appointment on 31 Dec 2022 at 7am to patient at index 2.
 
+**Example Usage:**
+- `apmt add i/1 d/2021-12-28 1500` 
+
+**Expected Outcome:**
+```
+New appointment added: 
+Patient: Alex Yeoh; Datetime: 28 Dec 2021 1500; Prescription: []
+```
+
 ### List all appointments: `apmt list`
 Shows the list of all appointments.
 
@@ -316,9 +329,11 @@ Shows the list of all appointments.
 **Expected Outcome:**
 ```
 [UI CARDS]
-1. Patient Name: Joshen Lim | Appointment Date: 2021-10-05
-2. Patient Name: Ian Yong | Appointment Date: 2021-10-06
-3. Patient Name: Didy Ne | Appointment Date: 2021-11-23
+1. Patient Name: Bernice Yu | Appointment Date: 2021-10-05
+2. Patient Name: Alex Yeoh | Appointment Date: 2021-10-06
+3. Patient Name: Charlotte Oliveiro | Appointment Date: 2021-11-23
+
+Listed all appointments
 ```
 
 ### List all archived appointments: `apmt alist`
@@ -332,9 +347,11 @@ Shows the list of all archived appointments.
 **Expected Outcome:**
 ```
 [UI CARDS]
-1. Patient Name: Joshen Lim | Appointment Date: 2021-10-05
-2. Patient Name: Ian Yong | Appointment Date: 2021-10-06
-3. Patient Name: Didy Ne | Appointment Date: 2021-11-23
+1. Patient Name: Bernice Yu | Appointment Date: 2021-1-05
+2. Patient Name: Alex Yeoh | Appointment Date: 2021-1-06
+3. Patient Name: Charlotte Oliveiro | Appointment Date: 2021-1-23
+
+Listed all archived appointments
 ```
 
 ### Edit an appointment: `apmt edit`
@@ -356,7 +373,14 @@ Edits the details of an appointment at the specified index in the Appointments p
 - `apmt edit 1 d/2021-10-28 1500`
 - `apmt edit 1 i/1 d/2021-10-28 1500`
 
----
+**Example Usage:**
+- `apmt edit 1 i/1 d/2021-12-25 1500`
+
+**Expected Outcome:**
+```
+Edited Appointment: 
+Patient: Alex Yeoh; Datetime: 25 Dec 2021 1500; Prescription: []
+```
 
 
 ### Delete an appointment: `apmt delete`
@@ -368,8 +392,18 @@ Deletes the appointment at the specified index in the Appointments panel.
 * The index must be a positive integer 1, 2, 3, ...
 
 **Examples:**
-* `apmt list`  Lists all appointments.
+* `apmt list`  Display Upcoming appointments tab.
 * `apmt delete 1`  Deletes appointment at index 1.
+
+**Example Usage:**
+- `apmt delete 1`
+
+**Expected Outcome:**
+```
+Deleted Appointment: 
+Patient: Alex Yeoh; Datetime: 28 Oct 2021 1500; Prescription: []
+
+```
 
 
 ### Archive an appointment: `apmt archive`
@@ -385,7 +419,8 @@ Archives an old appointment that is already past its date.
 
 **Expected Outcome:**
 ```
-Archived Appointment: David Li; Phone: 91031282; Email: lidavid@example.com; Address: Blk 436 Serangoon Gardens Street 26, #16-43; Tags: [family]; Medical History: lovesick; Datetime: 2022-05-05 1300
+Archived Appointment: 
+Patient: Alex Yeoh; Datetime: 31 Dec 2012 1200; Prescription: []
 ```
 
 ### Sort all appointments: `apmt sort`
@@ -398,10 +433,13 @@ Shows a sorted list of all appointments
 
 **Expected Outcome:**
 ```
-1. Patient Name: Didymus Ne | Appointment Date: 2021-06-05
-2. Patient Name: Hu Yuxin | Appointment Date: 2021-07-21
-3. Patient Name: Joshen Lim | Appointment Date: 2021-10-05
-4. Patient Name: Ian Yong | Appointment Date: 2021-10-06
+[UI CARDS]
+1. Patient Name: Bernice Yu | Appointment Date: 2021-06-05
+2. Patient Name: Charlotte Oliveiro | Appointment Date: 2021-07-21
+3. Patient Name: Alex Yeoh | Appointment Date: 2021-10-05
+4. Patient Name: David Li | Appointment Date: 2021-10-06
+
+Sorted Appointments based on default settings.
 ```
 ## Add prescription: `apmt pa`
 Adds a prescription to the designated appointment.

--- a/src/main/java/seedu/docit/logic/commands/ArchiveAppointmentCommand.java
+++ b/src/main/java/seedu/docit/logic/commands/ArchiveAppointmentCommand.java
@@ -21,7 +21,7 @@ public class ArchiveAppointmentCommand extends AppointmentCommand {
             + ": Archives the appointment identified by the index number used in the displayed appointment list.\n"
             + "Parameters: INDEX (must be a positive integer)\n" + "Example: apmt " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_ARCHIVE_APPOINTMENT_SUCCESS = "Archived Appointment: %1$s";
+    public static final String MESSAGE_ARCHIVE_APPOINTMENT_SUCCESS = "Archived Appointment: \n%1$s";
     public static final String MESSAGE_DUPLICATE_APPOINTMENT =
             "This appointment already exists in the archives. Removing appointment.";
 

--- a/src/main/java/seedu/docit/logic/parser/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/docit/logic/parser/EditAppointmentCommandParser.java
@@ -5,6 +5,8 @@ import static seedu.docit.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.docit.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.docit.logic.parser.CliSyntax.PREFIX_INDEX;
 
+import java.time.LocalDateTime;
+
 import seedu.docit.commons.core.index.Index;
 import seedu.docit.logic.commands.EditAppointmentCommand;
 import seedu.docit.logic.commands.EditAppointmentCommand.EditAppointmentDescriptor;
@@ -47,9 +49,15 @@ public class EditAppointmentCommandParser implements AppointmentParser<EditAppoi
             editAppointmentDescriptor.setPatientIndex(patientIndex);
         }
         if (argMultimap.getValue(CliSyntax.PREFIX_DATETIME).isPresent()) {
-            editAppointmentDescriptor.setDatetime(
-                ParserUtil.parseDateTime(argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get(),
-                    ParserUtil.INPUT_DATE_TIME_FORMATTER));
+            LocalDateTime localDateTime;
+            try {
+                localDateTime = ParserUtil.parseDateTime(argMultimap.getValue(CliSyntax.PREFIX_DATETIME).get(),
+                    ParserUtil.INPUT_DATE_TIME_FORMATTER);
+            } catch (ParseException pe) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditAppointmentCommand.MESSAGE_USAGE), pe);
+            }
+            editAppointmentDescriptor.setDatetime(localDateTime);
         }
 
         if (!editAppointmentDescriptor.isAnyFieldEdited()) {

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -182,7 +182,7 @@ public class ParserUtil {
         if (isNumericalOnly(trimmedMedicalEntry)) {
             throw new ParseException(MedicalHistory.MESSAGE_CONSTRAINTS);
         }
-        if (!isValidMedicalEntry(trimmedMedicalEntry)) {
+        if (!MedicalHistory.isValidMedicalEntry(trimmedMedicalEntry)) {
             return MedicalHistory.EMPTY_MEDICAL_HISTORY;
         }
         return new MedicalHistory(trimmedMedicalEntry);
@@ -210,10 +210,6 @@ public class ParserUtil {
         }
 
         return toParseMh.size() == 0 ? MedicalHistory.EMPTY_MEDICAL_HISTORY : toParseMh;
-    }
-
-    private static boolean isValidMedicalEntry(String entry) {
-        return !(entry.length() == 0 || entry == " " || entry == null);
     }
 
     /**

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -29,6 +29,7 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DATETIME = "%s is incorrect datetime format.";
+    public static final String MESSAGE_INVALID_NUMERICAL_ONLY = "%s cannot be numerical only.";
     public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy HHmm");
     public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-M-d HHmm");
 
@@ -216,5 +217,12 @@ public class ParserUtil {
      */
     public static boolean hasAllPrefixes(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    private static boolean isNumericalOnly(String input) {
+        requireNonNull(input);
+        Pattern p = Pattern.compile("^[0-9]*$");
+        Matcher m = p.matcher(input);
+        return m.matches();
     }
 }

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -85,6 +85,9 @@ public class ParserUtil {
     public static Address parseAddress(String address) throws ParseException {
         requireNonNull(address);
         String trimmedAddress = address.trim();
+        if (isNumericalOnly(trimmedAddress)) {
+            throw new ParseException(Address.MESSAGE_CONSTRAINTS);
+        }
         if (!Address.isValidAddress(trimmedAddress)) {
             throw new ParseException(Address.MESSAGE_CONSTRAINTS);
         }
@@ -172,14 +175,16 @@ public class ParserUtil {
     /**
      * Parses {@code String medicalEntry} into a {@code MedicalHistory}.
      */
-    public static MedicalHistory parseMedicalEntry(String medicalEntry) {
+    public static MedicalHistory parseMedicalEntry(String medicalEntry) throws ParseException {
         requireNonNull(medicalEntry);
         String trimmedMedicalEntry = medicalEntry.trim();
 
+        if (isNumericalOnly(trimmedMedicalEntry)) {
+            throw new ParseException(MedicalHistory.MESSAGE_CONSTRAINTS);
+        }
         if (!isValidMedicalEntry(trimmedMedicalEntry)) {
             return MedicalHistory.EMPTY_MEDICAL_HISTORY;
         }
-
         return new MedicalHistory(trimmedMedicalEntry);
     }
 
@@ -188,7 +193,7 @@ public class ParserUtil {
      * @param medicalEntries an empty Arraylist.
      * @return an empty medical history.
      */
-    public static MedicalHistory parseMedicalHistory(Collection<String> medicalEntries) {
+    public static MedicalHistory parseMedicalHistory(Collection<String> medicalEntries) throws ParseException {
         requireNonNull(medicalEntries);
 
         MedicalHistory toParseMh = new MedicalHistory("");

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -8,6 +8,8 @@ import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import seedu.docit.commons.core.index.Index;
@@ -138,6 +140,26 @@ public class ParserUtil {
         if (formatter == null) {
             formatter = DEFAULT_DATE_TIME_FORMATTER;
         }
+
+        Pattern p = Pattern.compile("(?<year>[0-9]{4})-[0-9]{1,2}-[0-9]{1,2} (?<hour>[0-9]{4})");
+        Matcher m = p.matcher(datetime);
+        if (!m.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
+        }
+
+        int year, hour;
+        try {
+            year = Integer.parseInt(m.group("year"));
+            hour = Integer.parseInt(m.group("hour"));
+        } catch (NumberFormatException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
+        }
+
+        // to limit inputs further
+        if (year < 2000 || year >= 3000 || hour == 2400) {
+            throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
+        }
+
         try {
             return LocalDateTime.parse(datetime, formatter);
         } catch (DateTimeParseException e) {
@@ -146,7 +168,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code String medicalEntry} into a {@Code MedicalHistory}.
+     * Parses {@code String medicalEntry} into a {@code MedicalHistory}.
      */
     public static MedicalHistory parseMedicalEntry(String medicalEntry) {
         requireNonNull(medicalEntry);

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -147,7 +147,8 @@ public class ParserUtil {
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
         }
 
-        int year, hour;
+        int year;
+        int hour;
         try {
             year = Integer.parseInt(m.group("year"));
             hour = Integer.parseInt(m.group("hour"));

--- a/src/main/java/seedu/docit/model/patient/Address.java
+++ b/src/main/java/seedu/docit/model/patient/Address.java
@@ -9,7 +9,8 @@ import static seedu.docit.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Address should only contain alphanumeric characters and spaces, "
+    public static final String MESSAGE_CONSTRAINTS = "Address should only contain alphanumeric characters, hash, "
+        + "dash, commas, and spaces, "
         + "should not be numerical only, "
         + "and should not be blank";
 
@@ -17,7 +18,7 @@ public class Address {
      * The first character of the docit must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum} #\\-,]*";
 
     public final String value;
 

--- a/src/main/java/seedu/docit/model/patient/Address.java
+++ b/src/main/java/seedu/docit/model/patient/Address.java
@@ -18,7 +18,7 @@ public class Address {
      * The first character of the docit must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum} #\\-,]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} #\\-,]*";
 
     public final String value;
 

--- a/src/main/java/seedu/docit/model/patient/Address.java
+++ b/src/main/java/seedu/docit/model/patient/Address.java
@@ -9,13 +9,15 @@ import static seedu.docit.commons.util.AppUtil.checkArgument;
  */
 public class Address {
 
-    public static final String MESSAGE_CONSTRAINTS = "Addresses can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Address should only contain alphanumeric characters and spaces, "
+        + "should not be numerical only, "
+        + "and should not be blank";
 
     /*
      * The first character of the docit must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
 
     public final String value;
 

--- a/src/main/java/seedu/docit/model/patient/MedicalHistory.java
+++ b/src/main/java/seedu/docit/model/patient/MedicalHistory.java
@@ -148,6 +148,9 @@ public class MedicalHistory {
 
     }
 
+    /**
+     * Returns true if a given string is a valid Medical Entry.
+     */
     public static boolean isValidMedicalEntry(String test) {
         return !(test.length() == 0 || test == " " || test == null)
             && test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/docit/model/patient/MedicalHistory.java
+++ b/src/main/java/seedu/docit/model/patient/MedicalHistory.java
@@ -10,11 +10,10 @@ import seedu.docit.model.EntryList;
 
 public class MedicalHistory {
     public static final MedicalHistory EMPTY_MEDICAL_HISTORY = new MedicalHistory(null);
-    private EntryList<Entry<MedicalEntry>> entryList = new EntryList<>();
-
     public static final String MESSAGE_CONSTRAINTS = "Medical History should be alphanumeric, "
         + "should not be numerical only, "
         + "and should not be blank";
+    private EntryList<Entry<MedicalEntry>> entryList = new EntryList<>();
 
     /**
      * Constructs an {@code DateOfBirth}.

--- a/src/main/java/seedu/docit/model/patient/MedicalHistory.java
+++ b/src/main/java/seedu/docit/model/patient/MedicalHistory.java
@@ -12,6 +12,10 @@ public class MedicalHistory {
     public static final MedicalHistory EMPTY_MEDICAL_HISTORY = new MedicalHistory(null);
     private EntryList<Entry<MedicalEntry>> entryList = new EntryList<>();
 
+    public static final String MESSAGE_CONSTRAINTS = "Medical History should be alphanumeric, "
+        + "should not be numerical only, "
+        + "and should not be blank";
+
     /**
      * Constructs an {@code DateOfBirth}.
      *

--- a/src/main/java/seedu/docit/model/patient/MedicalHistory.java
+++ b/src/main/java/seedu/docit/model/patient/MedicalHistory.java
@@ -10,9 +10,12 @@ import seedu.docit.model.EntryList;
 
 public class MedicalHistory {
     public static final MedicalHistory EMPTY_MEDICAL_HISTORY = new MedicalHistory(null);
-    public static final String MESSAGE_CONSTRAINTS = "Medical History should be alphanumeric, "
+    public static final String MESSAGE_CONSTRAINTS = "Medical History should only contain alphanumeric characters, "
+        + "dash, commas, and spaces, "
         + "should not be numerical only, "
         + "and should not be blank";
+    public static final String VALIDATION_REGEX = "[\\p{Alnum} \\-,]*";
+
     private EntryList<Entry<MedicalEntry>> entryList = new EntryList<>();
 
     /**
@@ -143,6 +146,11 @@ public class MedicalHistory {
 
         return s.toString();
 
+    }
+
+    public static boolean isValidMedicalEntry(String test) {
+        return !(test.length() == 0 || test == " " || test == null)
+            && test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/docit/model/patient/Name.java
+++ b/src/main/java/seedu/docit/model/patient/Name.java
@@ -10,13 +10,13 @@ import static seedu.docit.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphabetic characters and spaces, and it should not be blank";
 
     /*
      * The first character of the docit must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public final String fullName;
 

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -2,7 +2,6 @@
 
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
-
 <StackPane fx:id="placeHolder" styleClass="pane-transparent" stylesheets="@LightTheme.css" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" />
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>

--- a/src/test/java/seedu/docit/model/person/AddressTest.java
+++ b/src/test/java/seedu/docit/model/person/AddressTest.java
@@ -27,10 +27,11 @@ public class AddressTest {
         // invalid addresses
         assertFalse(Address.isValidAddress("")); // empty string
         assertFalse(Address.isValidAddress(" ")); // spaces only
+        assertFalse(Address.isValidAddress("-"));
 
         // valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));
-        assertTrue(Address.isValidAddress("-")); // one character
-        assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long docit
+        assertTrue(Address.isValidAddress("a")); // one character
+        assertTrue(Address.isValidAddress("Leng Inc, 1234 Market S, San Francisco CA 2349879, USA")); // long docit
     }
 }

--- a/src/test/java/seedu/docit/model/person/NameTest.java
+++ b/src/test/java/seedu/docit/model/person/NameTest.java
@@ -29,12 +29,13 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("12345")); // numbers only
+        assertFalse(Name.isValidName("peter the 2nd")); // alphanumeric characters
+
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr")); // long names
     }
 }


### PR DESCRIPTION
Changes:
* Change apmt edit 'datetime is invalid' message to show invalid command message.
   Fixes #225
* Restrict parsers
  * Datetime to years 2000-2999, disallow 2400 hour input
    Fixes #186
  * Name to alphabetical characters
  * Address to alphanumerical and hash, dash, comma characters, cannot be numerical only
  * Medical History to alphanumerical, dash, comma characters, cannot be numerical only
     Fixes #206, Resolves #237
* Change ResultDisplay to wrap text
   Fixes #204
* Change Expected Outcome for appointments
   Fixes #209