### PR TITLE
Change Date Time parsing to use strict parsing

### DIFF
--- a/src/main/java/seedu/docit/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/docit/logic/parser/AddAppointmentCommandParser.java
@@ -3,7 +3,6 @@ package seedu.docit.logic.parser;
 import static seedu.docit.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 import seedu.docit.commons.core.index.Index;
 import seedu.docit.logic.commands.AddAppointmentCommand;
@@ -13,8 +12,6 @@ import seedu.docit.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new AddAppointmentCommand object
  */
 public class AddAppointmentCommandParser implements AppointmentParser<AddAppointmentCommand> {
-    public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-M-d HHmm");
-    public static final DateTimeFormatter FANCY_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy HHmm");
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddAppointmentCommand and returns an
@@ -44,7 +41,7 @@ public class AddAppointmentCommandParser implements AppointmentParser<AddAppoint
 
         LocalDateTime localDateTime;
         try {
-            localDateTime = ParserUtil.parseDateTime(datetime, DEFAULT_DATE_TIME_FORMATTER);
+            localDateTime = ParserUtil.parseDateTime(datetime, ParserUtil.INPUT_DATE_TIME_FORMATTER);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddAppointmentCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -33,9 +33,10 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DATETIME = "%s is incorrect datetime format.";
     public static final String MESSAGE_INVALID_NUMERICAL_ONLY = "%s cannot be numerical only.";
-    private static final Logger logger = LogsCenter.getLogger(ParserUtil.class);
     public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu HHmm");
     public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-M-d HHmm");
+
+    private static final Logger logger = LogsCenter.getLogger(ParserUtil.class);
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -36,6 +36,10 @@ public class ParserUtil {
     public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu HHmm");
     public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-M-d HHmm");
 
+    private static final int min_year = 2000;
+    private static final int max_year = 2999;
+    private static final int max_hour = 2359;
+
     private static final Logger logger = LogsCenter.getLogger(ParserUtil.class);
 
     /**
@@ -166,7 +170,7 @@ public class ParserUtil {
         }
 
         // to limit inputs further
-        if (year < 2000 || year >= 3000 || hour == 2400) {
+        if (year < min_year || year > max_year || hour > max_hour) {
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
         }
 

--- a/src/main/java/seedu/docit/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/docit/logic/parser/ParserUtil.java
@@ -5,13 +5,16 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import seedu.docit.commons.core.LogsCenter;
 import seedu.docit.commons.core.index.Index;
 import seedu.docit.commons.util.StringUtil;
 import seedu.docit.logic.parser.exceptions.ParseException;
@@ -30,8 +33,9 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_DATETIME = "%s is incorrect datetime format.";
     public static final String MESSAGE_INVALID_NUMERICAL_ONLY = "%s cannot be numerical only.";
-    public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy HHmm");
-    public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-M-d HHmm");
+    private static final Logger logger = LogsCenter.getLogger(ParserUtil.class);
+    public static final DateTimeFormatter DEFAULT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu HHmm");
+    public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-M-d HHmm");
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -166,8 +170,9 @@ public class ParserUtil {
         }
 
         try {
-            return LocalDateTime.parse(datetime, formatter);
+            return LocalDateTime.parse(datetime, formatter.withResolverStyle(ResolverStyle.STRICT));
         } catch (DateTimeParseException e) {
+            logger.warning(e.getMessage());
             throw new ParseException(String.format(MESSAGE_INVALID_DATETIME, datetime));
         }
     }

--- a/src/main/java/seedu/docit/model/appointment/Appointment.java
+++ b/src/main/java/seedu/docit/model/appointment/Appointment.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import seedu.docit.logic.parser.ParserUtil;
 import seedu.docit.model.patient.Patient;
 import seedu.docit.model.prescription.Prescription;
 import seedu.docit.model.prescription.exceptions.DuplicatePrescriptionException;
@@ -24,7 +25,6 @@ public class Appointment implements Comparable<Appointment> {
     public static final DateTimeFormatter UI_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy HHmm");
     public static final DateTimeFormatter UI_DATE_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy");
     public static final DateTimeFormatter UI_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
-    public static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-M-d HHmm");
 
     // Identity fields
     private final Patient patient;
@@ -115,7 +115,7 @@ public class Appointment implements Comparable<Appointment> {
     }
 
     public String getInputFormattedDatetimeString() {
-        return getDatetime().format(INPUT_DATE_TIME_FORMATTER);
+        return getDatetime().format(ParserUtil.INPUT_DATE_TIME_FORMATTER);
     }
 
     /**

--- a/src/main/java/seedu/docit/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/docit/storage/JsonAdaptedAppointment.java
@@ -48,7 +48,7 @@ public class JsonAdaptedAppointment {
      */
     public JsonAdaptedAppointment(Appointment source, ReadOnlyAddressBook addressBook) {
         patientIndex = Integer.toString(addressBook.getIndexOfPatient(source.getPatient()).getZeroBased());
-        datetime = source.getFormattedDatetimeString();
+        datetime = source.getInputFormattedDatetimeString();
         prescriptionList.addAll(source.getPrescriptions()
                         .stream().map(JsonAdaptedPrescription::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/seedu/docit/storage/JsonAdaptedAppointment.java
+++ b/src/main/java/seedu/docit/storage/JsonAdaptedAppointment.java
@@ -1,7 +1,6 @@
 package seedu.docit.storage;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -26,7 +25,6 @@ import seedu.docit.model.prescription.Prescription;
 public class JsonAdaptedAppointment {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Appointment's %s field is missing!";
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM yyyy HHmm");
 
     private final String patientIndex;
     private final String datetime;
@@ -86,7 +84,7 @@ public class JsonAdaptedAppointment {
 
         LocalDateTime localDateTime;
         try {
-            localDateTime = ParserUtil.parseDateTime(datetime, DATE_TIME_FORMATTER);
+            localDateTime = ParserUtil.parseDateTime(datetime, ParserUtil.INPUT_DATE_TIME_FORMATTER);
         } catch (ParseException e) {
             throw new IllegalValueException(LocalDateTime.class.getSimpleName() + " is of incorrect format.");
         }


### PR DESCRIPTION
* Change Date Time Formatter to use strict parsing
Fixes #259
* Add logging for parseDateTime for easier debugging
* Change Parsers to use the same DateTimeFormatter at ParserUtil for easier code maintenance
Date and time are now stored in the same format they were inputted in
Fixes #257 